### PR TITLE
fix(docular task): return the result of process_gen_docs_done()

### DIFF
--- a/tasks/docular.js
+++ b/tasks/docular.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
         docular.genDocs(options, function(){
 
             //make good on the async promise
-            process_gen_docs_done();
+            return process_gen_docs_done();
         });
 
     });


### PR DESCRIPTION
This PR should paired with a separate docular PR coming soon.

Without returning the result of process_gen_docs_done(), no additional tasks are run in grunt.
